### PR TITLE
Make a videojs preset based on angular preset

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -50,10 +50,21 @@ If the commit reverts a previous commit, it should begin with `revert: `, follow
 
 ### Type
 
-If the prefix is `feat`, `fix` or `perf`, it will appear in the changelog. However if there is any [BREAKING CHANGE](#footer), the commit will always appear in the changelog.
+Support types are:
+* `feat`: Feature
+* `fix`: Bug Fixes
+* `perf`: Performance Improvements
+* `revert`: Reverts
+* `docs`: Documentation
+* `style`: Styles
+* `refactor`: Code Refactoring
+* `test`: Tests
+* `chore`: Chores
 
-Other prefixes are up to your discretion. Suggested prefixes are `docs`, `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
+Only these types will appear in the changelog. However if there is any [BREAKING CHANGE](#footer), the commit will always appear in the changelog.
+These types are sorted by BREAKING CHANGE, Features, Bug Fixes showing up first for each group followed by the other types sorted alphabetically.
 
+Other prefixes are up to your discretion and will not appear in the changelog by default.
 ### Scope
 
 The scope could be anything specifying place of the commit change. For example `$location`,

--- a/index.js
+++ b/index.js
@@ -102,7 +102,37 @@ var writerOpts = {
     return commit;
   },
   groupBy: 'type',
-  commitGroupsSort: 'title',
+  commitGroupsSort: 
+  commitGroupsSort: function(group1, group2) {
+    if (group1.title === 'BREAKING CHANGES') {
+      return -1;
+    }
+    if (group2.title === 'BREAKING CHANGES') {
+      return 1;
+    }
+
+    if (group1.title === 'Features') {
+      return -1;
+    }
+    if (group2.title === 'Features') {
+      return 1;
+    }
+
+    if (group1.title === 'Bux Fixes') {
+      return -1;
+    }
+    if (group2.title === 'Bug Fixes') {
+      return 1;
+    }
+
+    if (group1.title < group2.title) {
+      return -1;
+    }
+    if (group2.title < group1.title) {
+      return 1;
+    }
+    return 0;
+  },
   commitsSort: ['scope', 'subject'],
   noteGroupsSort: 'title',
   notesSort: compareFunc

--- a/index.js
+++ b/index.js
@@ -55,8 +55,6 @@ var writerOpts = {
       commit.type = 'Performance Improvements';
     } else if (commit.type === 'revert') {
       commit.type = 'Reverts';
-    } else if (discard) {
-      return;
     } else if (commit.type === 'docs') {
       commit.type = 'Documentation';
     } else if (commit.type === 'style') {
@@ -67,7 +65,8 @@ var writerOpts = {
       commit.type = 'Tests';
     } else if (commit.type === 'chore') {
       commit.type = 'Chores';
-    }
+    } else if (discard) {
+      return;
 
     if (commit.scope === '*') {
       commit.scope = '';

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ var writerOpts = {
       commit.type = 'Chores';
     } else if (discard) {
       return;
+    }
 
     if (commit.scope === '*') {
       commit.scope = '';
@@ -102,7 +103,6 @@ var writerOpts = {
     return commit;
   },
   groupBy: 'type',
-  commitGroupsSort: 
   commitGroupsSort: function(group1, group2) {
     if (group1.title === 'BREAKING CHANGES') {
       return -1;

--- a/index.js
+++ b/index.js
@@ -104,25 +104,15 @@ var writerOpts = {
   },
   groupBy: 'type',
   commitGroupsSort: function(group1, group2) {
-    if (group1.title === 'BREAKING CHANGES') {
-      return -1;
-    }
-    if (group2.title === 'BREAKING CHANGES') {
-      return 1;
-    }
+    var priority = ['BREAKING CHANGES', 'Features', 'Bug Fixes'];
 
-    if (group1.title === 'Features') {
-      return -1;
-    }
-    if (group2.title === 'Features') {
-      return 1;
-    }
-
-    if (group1.title === 'Bux Fixes') {
-      return -1;
-    }
-    if (group2.title === 'Bug Fixes') {
-      return 1;
+    for (var i = 0; i < priority.length; i++) {
+      if (group1.title === priority[i]) {
+        return -1;
+      }
+      if (group2.title === priority[i]) {
+        return 1;
+      }
     }
 
     if (group1.title < group2.title) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "coverage": "istanbul cover -x test.js _mocha -- -R spec --timeout 30000 && rm -rf ./coverage",
     "lint": "jshint *.js --exclude node_modules && jscs *.js",
-    "test": "mocha --timeout 30000 && npm run-script lint"
+    "pretest": "npm run lint",
+    "test": "mocha --timeout 30000"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "conventional-changelog-angular",
-  "version": "1.3.0",
-  "description": "conventional-changelog angular preset",
+  "name": "conventional-changelog-videojs",
+  "version": "0.0.0",
+  "description": "conventional-changelog videojs preset",
   "main": "index.js",
   "scripts": {
     "coverage": "istanbul cover -x test.js _mocha -- -R spec --timeout 30000 && rm -rf ./coverage",
@@ -10,19 +10,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/conventional-changelog-angular.git"
+    "url": "git+https://github.com/conventional-changelog/conventional-changelog-videojs.git"
   },
   "keywords": [
     "conventional-changelog",
-    "angular",
+    "videojs",
     "preset"
   ],
   "author": "Steve Mao",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/conventional-changelog/conventional-changelog-angular/issues"
+    "url": "https://github.com/conventional-changelog/conventional-changelog-videojs/issues"
   },
-  "homepage": "https://github.com/conventional-changelog/conventional-changelog-angular#readme",
+  "homepage": "https://github.com/conventional-changelog/conventional-changelog-videojs#readme",
   "devDependencies": {
     "better-than-before": "^1.0.0",
     "chai": "^3.4.1",

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,19 @@
 #  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
 
-> [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [angular](https://github.com/angular/angular) preset
+> [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) [videojs](https://github.com/videojs/video.js) preset
 
+This is based on the [angular preset](https://github.com/conventional-changelog/conventional-changelog-angular). The main difference is that instead of only allowing `feat`, `fix`, and `perf` in the changelog, everything shows up but the important parts (breaking changes, features, bug fixes) are sorted first.
 
 See [convention](convention.md)
 
-**Issues with the convention itself should be reported on the angular issue tracker.**
+**Issues with the convention itself should be reported on the here.**
 
 
-[npm-image]: https://badge.fury.io/js/conventional-changelog-angular.svg
-[npm-url]: https://npmjs.org/package/conventional-changelog-angular
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-angular.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-angular
-[daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-angular.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-angular
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-angular/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-angular
+[npm-image]: https://badge.fury.io/js/conventional-changelog-videojs.svg
+[npm-url]: https://npmjs.org/package/conventional-changelog-videojs
+[travis-image]: https://travis-ci.org/videojs/conventional-changelog-video.js.svg?branch=master
+[travis-url]: https://travis-ci.org/videojs/conventional-changelog-videojs
+[daviddm-image]: https://david-dm.org/videojs/conventional-changelog-videojs.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/videojs/conventional-changelog-videojs
+[coveralls-image]: https://coveralls.io/repos/videojs/conventional-changelog-videojs/badge.svg
+[coveralls-url]: https://coveralls.io/r/videojs/conventional-changelog-videojs

--- a/templates/template.hbs
+++ b/templates/template.hbs
@@ -2,15 +2,13 @@
 
 {{#each commitGroups}}
 
-{{#if title}}
+{{~#if title}}
 ### {{title}}
 
 {{/if}}
-{{#each commits}}
+{{~#each commits}}
 {{> commit root=@root}}
 {{/each}}
 
 {{/each}}
 {{> footer}}
-
-

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,7 @@ betterThanBefore.setups([
   }
 ]);
 
-describe('angular preset', function() {
+describe('videojs preset', function() {
   it('should work if there is no semver tag', function(done) {
     preparing(1);
 
@@ -99,7 +99,7 @@ describe('angular preset', function() {
       })
       .pipe(through(function(chunk) {
         chunk = chunk.toString();
-        expect(chunk).to.include('[#133](https://github.com/conventional-changelog/conventional-changelog-angular/issues/133)');
+        expect(chunk).to.include('[#133](https://github.com/conventional-changelog/conventional-changelog-videojs/issues/133)');
         done();
       }));
   });
@@ -115,8 +115,8 @@ describe('angular preset', function() {
       })
       .pipe(through(function(chunk) {
         chunk = chunk.toString();
-        expect(chunk).to.include('[#88](https://github.com/conventional-changelog/conventional-changelog-angular/issues/88)');
-        expect(chunk).to.not.include('closes [#88](https://github.com/conventional-changelog/conventional-changelog-angular/issues/88)');
+        expect(chunk).to.include('[#88](https://github.com/conventional-changelog/conventional-changelog-videojs/issues/88)');
+        expect(chunk).to.not.include('closes [#88](https://github.com/conventional-changelog/conventional-changelog-videojs/issues/88)');
         done();
       }));
   });

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,7 @@ describe('angular preset', function() {
         expect(chunk).to.include('amazing new module');
         expect(chunk).to.include('**compile:** avoid a bug');
         expect(chunk).to.include('make it faster');
-        expect(chunk).to.include(', closes [#1](https://github.com/conventional-changelog/conventional-changelog-angular/issues/1) [#2](https://github.com/conventional-changelog/conventional-changelog-angular/issues/2)');
+        expect(chunk).to.include(', closes [#1](https://github.com/conventional-changelog/conventional-changelog-videojs/issues/1) [#2](https://github.com/conventional-changelog/conventional-changelog-videojs/issues/2)');
         expect(chunk).to.include('Not backward compatible.');
         expect(chunk).to.include('**compile:** The Change is huge.');
         expect(chunk).to.include('Features');
@@ -75,8 +75,8 @@ describe('angular preset', function() {
         expect(chunk).to.include('Reverts');
         expect(chunk).to.include('bad commit');
         expect(chunk).to.include('BREAKING CHANGES');
+        expect(chunk).to.include('first commit');
 
-        expect(chunk).to.not.include('first commit');
         expect(chunk).to.not.include('feat');
         expect(chunk).to.not.include('fix');
         expect(chunk).to.not.include('perf');


### PR DESCRIPTION
The main difference is that it allows all of the known commit groups into the changelog. It then sorts them by BREAKING CHANGE, then Features, then Bug Fixes, finally following by each other commit group sorted by the group's title.
